### PR TITLE
Bugfix 23

### DIFF
--- a/framework/include/kernels.h
+++ b/framework/include/kernels.h
@@ -13,7 +13,7 @@
  * IL and IR are the left/right original images with x * y * nc
  */
 __global__ void g_compute_rho(float *iL, float *iR, float *Rho, int w, int h,
-		int nc, int gamma_min, int gamma_max, float lambda);
+		int nc, int gamma_min, int gamma_max, float lambda, float dg);
 
 /**
  * Initialize Phi with entries 1.0 in layer gamma_min

--- a/framework/main.cu
+++ b/framework/main.cu
@@ -242,7 +242,7 @@ cv::Mat calculate_disparities(const config c)
 		// check convergence
 		float energy_host = 0.f;
 
-		if (iterations % (c.max_iterations / 5) == 0)
+		if (iterations % (c.max_iterations / 10) == 0)
 		{
 			cudaMemset(energy, 0, sizeof(float));
 			CUDA_CHECK;

--- a/framework/main.cu
+++ b/framework/main.cu
@@ -198,8 +198,6 @@ cv::Mat calculate_disparities(const config c)
 	g_init_phi<<<grid2D, block2D>>>(Phi, w, h, gc);
 	CUDA_CHECK;
 
-	check_Phi(Phi, w, h, gc);
-
 	// Compute a global rho (that doesn't change...)
 	g_compute_rho<<<grid2D, block2D>>>(IL, IR, Rho, w, h, nc, c.gamma_min,
 			c.gamma_max, c.lambda, c.dg);
@@ -229,8 +227,6 @@ cv::Mat calculate_disparities(const config c)
 		g_update_phi<<<grid2D, block2D>>>(Phi, Div3_P, w, h, gc, c.tau_p);
 		CUDA_CHECK;
 
-		check_Phi(Phi, w, h, gc);
-
 		// Calculate the gradient in x, y, and gamma direction
 		g_grad3<<<grid2D, block2D>>>(Phi, Grad3_Phi, w, h, gc, c.dx, c.dy,
 				c.dg);
@@ -254,7 +250,6 @@ cv::Mat calculate_disparities(const config c)
 			g_compute_energy<<<grid2D, block2D>>>(Grad3_Phi, Phi, Rho, energy,
 					w, h, gc, c.lambda);
 			CUDA_CHECK;
-
 
 			cudaMemcpy(&energy_host, energy, sizeof(float),
 					cudaMemcpyDeviceToHost);

--- a/framework/main.cu
+++ b/framework/main.cu
@@ -201,7 +201,7 @@ cv::Mat calculate_disparities(const config c)
 
 	// Compute a global rho (that doesn't change...)
 	g_compute_rho<<<grid2D, block2D>>>(IL, IR, Rho, w, h, nc, c.gamma_min,
-			c.gamma_max, c.lambda);
+			c.gamma_max, c.lambda, c.dg);
 	CUDA_CHECK;
 
 	for (int g = 0; g < gc; g++)
@@ -390,7 +390,7 @@ cv::Mat adaptive_diffusion(const cv::Mat mDisparities, const cv::Mat mIn,
 			c.radius);
 	CUDA_CHECK;
 
-	// Normalize to [0, 1]
+	//Normalize to [0, 1]
 	normalize(G, w, h, 0.f, 1.f);
 
 	save_from_GPU("depths", Depths, w, h);
@@ -428,7 +428,6 @@ cv::Mat adaptive_diffusion(const cv::Mat mDisparities, const cv::Mat mIn,
 	CUDA_CHECK;
 
 	convert_layered_to_mat(mDiffused, imgIn);
-
 	// free memory
 	cudaFree(In);
 	CUDA_CHECK;
@@ -448,7 +447,7 @@ cv::Mat adaptive_diffusion(const cv::Mat mDisparities, const cv::Mat mIn,
 	delete[] imgIn;
 	delete[] imgDisparities;
 
-	return mDiffused;
+	return mDisparities;
 }
 
 int main(int argc, char **argv)
@@ -489,7 +488,8 @@ int main(int argc, char **argv)
 
 	// Reduce range from [0, 255] to [0, 1]
 	mDisparities /= 255.f;
-	//normalize(mDisparities, mDisparities, 0.f, 1.f, cv::NORM_MINMAX, CV_32FC1);
+
+	normalize(mDisparities, mDisparities, 0.f, 1.f, cv::NORM_MINMAX, CV_32FC1);
 	showImage("Disparities", mDisparities, 600, 100);
 	save_image("disparities", mDisparities);
 

--- a/framework/main.cu
+++ b/framework/main.cu
@@ -14,7 +14,7 @@ void check_Phi(float * Phi, int w, int h, int gc)
 {
 	cudaDeviceSynchronize();
 
-	float * phi_check = new float[w * h];
+	float phi_check[w * h];
 	for (int g = 0; g < gc; g++)
 	{
 		cudaMemcpy(phi_check, &Phi[g * w * h], w * h * sizeof(float),
@@ -36,16 +36,17 @@ void check_Phi(float * Phi, int w, int h, int gc)
 			}
 		}
 	}
+
 }
 
 void check_P(float * P, float *Rho, int w, int h, int gc)
 {
 	cudaDeviceSynchronize();
 
-	float * p1_check = new float[w * h];
-	float * p2_check = new float[w * h];
-	float * p3_check = new float[w * h];
-	float * rho = new float[w * h];
+	float p1_check[w * h];
+	float p2_check[w * h];
+	float p3_check[w * h];
+	float rho[w * h];
 
 	for (int g = 0; g < gc; g++)
 	{
@@ -239,14 +240,14 @@ cv::Mat calculate_disparities(const config c)
 		g_update_p<<<grid2D, block2D>>>(P, Grad3_Phi, Rho, w, h, gc, c.tau_d);
 		CUDA_CHECK;
 
-		if (iterations >= c.max_iterations)
+		if (iterations > c.max_iterations)
 			break;
 
 		// check convergence
+		float energy_host = 0.f;
+
 		if (iterations % (c.max_iterations / 5) == 0)
 		{
-			cout << "Iteration " << iterations << endl;
-
 			cudaMemset(energy, 0, sizeof(float));
 			CUDA_CHECK;
 
@@ -254,7 +255,7 @@ cv::Mat calculate_disparities(const config c)
 					w, h, gc, c.lambda);
 			CUDA_CHECK;
 
-			float energy_host = 0.f;
+
 			cudaMemcpy(&energy_host, energy, sizeof(float),
 					cudaMemcpyDeviceToHost);
 			CUDA_CHECK;
@@ -447,7 +448,7 @@ cv::Mat adaptive_diffusion(const cv::Mat mDisparities, const cv::Mat mIn,
 	delete[] imgIn;
 	delete[] imgDisparities;
 
-	return mDisparities;
+	return mDiffused;
 }
 
 int main(int argc, char **argv)

--- a/framework/src/kernels.cu
+++ b/framework/src/kernels.cu
@@ -183,7 +183,6 @@ __global__ void g_compute_u(float *Phi, float *U, int w, int h, int gamma_min,
 		float u = gamma_min;
 		for (int g = 0; g < gamma_max - gamma_min; g++)
 		{
-			// TODO: Need to apply dg here?
 			u += read_data(Phi, w, h, gamma_max - gamma_min, x, y, g);
 		}
 		write_data(U, u, w, h, x, y);

--- a/framework/src/kernels.cu
+++ b/framework/src/kernels.cu
@@ -4,7 +4,7 @@
 
 // TODO: Use shared memory to load data from iL and iR to shared memory
 __global__ void g_compute_rho(float *iL, float *iR, float *Rho, int w, int h,
-		int nc, int gamma_min, int gamma_max, float lambda)
+		int nc, int gamma_min, int gamma_max, float lambda, float dg)
 {
 	int x = threadIdx.x + blockDim.x * blockIdx.x;
 	int y = threadIdx.y + blockDim.y * blockIdx.y;
@@ -20,7 +20,7 @@ __global__ void g_compute_rho(float *iL, float *iR, float *Rho, int w, int h,
 			for (int c = 0; c < nc; c++)
 			{
 				float il = read_data(iL, w, h, nc, x, y, c);
-				float ir = read_data(iR, w, h, nc, x - g, y, c);
+				float ir = read_data(iR, w, h, nc, x - (g * dg), y, c);
 				r += lambda * fabs(il - ir);
 			}
 			// Create entry at layer g (normalized to range from 0 to gamma_max - gamma_min)
@@ -183,7 +183,8 @@ __global__ void g_compute_u(float *Phi, float *U, int w, int h, int gamma_min,
 		float u = gamma_min;
 		for (int g = 0; g < gamma_max - gamma_min; g++)
 		{
-			u += round(read_data(Phi, w, h, gamma_max - gamma_min, x, y, g));
+			// TODO: Need to apply dg here?
+			u += read_data(Phi, w, h, gamma_max - gamma_min, x, y, g);
 		}
 		write_data(U, u, w, h, x, y);
 	}

--- a/framework/src/usage.cu
+++ b/framework/src/usage.cu
@@ -106,7 +106,7 @@ void read_parameters(config &conf, int argc, char **argv)
 	conf.max_h = 2000;
 	conf.dx = 1.f;
 	conf.dy = 1.f;
-	conf.dg = .5f;
+	conf.dg = 1.f;
 	conf.gray = false;
 	conf.disparities_from_file = false;
 	conf.lambda = 30.f;
@@ -145,6 +145,12 @@ void read_parameters(config &conf, int argc, char **argv)
 	getParam("tau_p", conf.tau_p, argc, argv);
 
 	getParam("tau_d", conf.tau_d, argc, argv);
+
+	getParam("dx", conf.dx, argc, argv);
+
+	getParam("dy", conf.dy, argc, argv);
+
+	getParam("dg", conf.dg, argc, argv);
 
 	getParam("tau", conf.tau, argc, argv);
 	if (conf.tau > 0.25f)


### PR DESCRIPTION
Fix #23 by multiplying dg during computation of rho.
It is now possible to execute much faster due to less gamma range required by increasing the dg parameter.
Eg: right image has disparities ranging from -20 to 260. 
dg = 1: -gamma_min -20 -gamma_max 260
dg = 10: -gamma_min -2 -gamma_max 26 (much faster, but less accurate)